### PR TITLE
feat: case handler to convert snake to camel or reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PHP Webservice
+# MM-WS - PHP Webservice Template
 
 ## Before using
 
@@ -102,7 +102,7 @@ the `yardbirds.php` file you'll just use `$param1`
 
 ## MVC Model
 
-This project is MVC based using the following flow:
+This project is MVC (actually Model-Controller-Entity) based using the following flow:
 
 ``` 
                                       ───────────── Handlers 
@@ -210,6 +210,27 @@ $gen->generate();
 Simply as that, all of the database tables (excluding view tables) will be in its folder models, entities and controllers
 in the MVC path. The folders MUST ALREADY EXISTS.
 
+#### String Case Handler
+
+You can convert snake_case to camelCase -- or CameCase -- and vice-versa
+
+```
+$values = [
+    'userName' => 'Garry',
+    'userPassword' => 'M&UhanL2'
+];
+
+$str = MMWS\Handler\CaseHandler::convert($values, 1);
+```
+
+`$str` will result in:
+```
+[
+   'user_name' => 'Garry'
+   'user_password' => 'M&UhanL2'
+]
+```
+
 ### General Functions
 
 In `functions.php` you can see a lot of useful functions, such as password generators,
@@ -276,4 +297,4 @@ unique id generator, token generator, error handlers, etc., but the most used ar
 │   └── System-messages.json (System messages definition used in get_sysmsg($errCode). Not HTTP errors.)
 └── index.php (Endpoint renderer)
 ```
- ### Thats all folks.
+ ### Simple as that.

--- a/app/partials/classes/handlers/CaseHandler.php
+++ b/app/partials/classes/handlers/CaseHandler.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace MMWS\Handler;
+
+class CaseHandler
+{
+    /**
+     * Converts a case type to another
+     * Default is to convert from snake_case to camelCase.
+     * Converts snake_case to camelCase or CamelCase. A key => value array will have
+     * its indexes converted not its values
+     * 
+     * @param String|Array<String[]> $content string or string to be converted
+     * @param Int $model scheme to convert cases. 0 for snake to camel and 1 to camel to snake. Default is 1.
+     * @param Bool $capitalize to capitalise cases into CaseType
+     * @param Array<String[]> options. A custom separator can be set to $model = 1 as 'separator' => '[any_char]'
+     * 
+     * @return String|Array<String[]> 
+     * 
+     * String example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::convert('user_name');
+     * 
+     * print_r($str) -> outputs: userName
+     * 
+     * Array example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::convert(['userName' => 'garry'], 1, true);
+     * 
+     * print_r($str) -> outputs: ['user_name' => 'garry']
+     * 
+     * Options
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::convert(['userName' => 'garry'], 1, true, ['separator' => '-']);
+     * 
+     * print_r($str) -> outputs: ['user-name' => 'garry']
+     * 
+     * ----------     
+     */
+    static function convert($content, Int $model = 0, Bool $capitalize = false, array $options = [])
+    {
+        switch($model){
+            case 0:
+                return self::snakeToCamel($content, $capitalize);
+            case 1:
+                return self::camelToSnake($content, $capitalize, $options);
+        }
+    }
+
+    /**
+     * Converts snake_case to camelCase or CamelCase. A key => value array will have
+     * its indexes converted not its values
+     * 
+     * String example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel('user_name');
+     * 
+     * print_r($str) will print userName
+     * 
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel('user_name', true);
+     * 
+     * print_r($str) will print UserName
+     * 
+     * Array example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel(['user_name' => 'garry'], true);
+     * 
+     * print_r($str) will print ['UserName' => 'garry']
+     * 
+     * ----------
+     * 
+     * @param String|Array<String[]> $content string or string to be converted
+     * @param Bool $capitalize capitalize CamelCase or camelCase
+     * 
+     * @return String|Array<String[]>
+     */
+    private static function snakeToCamel($content, Bool $capitalize = false)
+    {
+        if (is_array($content)) {
+            $output = array();
+            /** Loops through the array to get the keys */
+            foreach ($content as $key => $value) {
+                $parts = explode('_', $key);
+
+                $outVarName = '';
+                /** Loops through every name part separated by underscore (_) */
+                $i = 0;
+                foreach ($parts as $part) {
+                    if ($i === 0 && !$capitalize) {
+                        $outVarName = strtolower($part);
+                        $i++;
+                        continue;
+                    }
+                    $outVarName .= ucfirst(strtolower($part));
+                    $i++;
+                }
+                $output[$outVarName] = $value;
+            }
+            return $output;
+        }
+
+        $parts = explode('_', $content);
+
+        $outVarName = '';
+        /** Loops through every name part separated by underscore (_) */
+        $i = 0;
+        foreach ($parts as $part) {
+            if ($i === 0 && !$capitalize) {
+                $outVarName = strtolower($part);
+                $i++;
+                continue;
+            }
+            $outVarName .= ucfirst(strtolower($part));
+            $i++;
+        }
+        return $outVarName;
+    }
+
+    /**
+     * Converts camelCase or CamelCase to snake_case or any separator. 
+     * A key => value array will have its indexes converted not its values
+     * 
+     * String example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel('userName');
+     * 
+     * print_r($str) will print user_name
+     * 
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel('userName', true);
+     * 
+     * print_r($str) will print User_Name
+     * 
+     * Array example
+     * ----------
+     * 
+     * $str = new MMWS\Handler\CaseHandler::snakeToCamel(['userName' => 'garry'], true, '-');
+     * 
+     * print_r($str) will print ['User-Name' => 'garry']
+     * 
+     * ----------
+     * 
+     * @param String|Array<String[]> $content string or string to be converted
+     * @param Bool $capitalize capitalize CamelCase or camelCase
+     * @param String $separator case word separator. Default is snake_case.
+     * 
+     * @return String|Array<String[]>
+     */
+    private static function camelToSnake($content, $capitalize = false, Array $options = [])
+    {
+        $separator = $options['separator'] ?? '_';
+        if (is_array($content)) {
+            $output = array();
+
+            /** Loops through the array to get the keys */
+            foreach ($content as $key => $value) {
+                $parts = preg_split('/(?=[A-Z])/', $key, -1, PREG_SPLIT_NO_EMPTY);
+
+                $outVarName = '';
+                /** Loops through every name part separated by case */
+                $i = 0;
+                foreach ($parts as $part) {
+                    $outVarName .= $separator . ucfirst(strtolower($part));
+                    $i++;
+                }
+                $outVarName = trim($outVarName, $separator);
+                if (!$capitalize) $outVarName = strtolower($outVarName);
+                $output[$outVarName] = $value;
+            }
+            return $output;
+        }
+
+        $parts = preg_split('/(?=[A-Z])/', $content, -1, PREG_SPLIT_NO_EMPTY);
+        $outVarName = '';
+
+        /** Loops through every name part separated by case */
+        $i = 0;
+        foreach ($parts as $part) {
+            $outVarName .= $separator . ucfirst(strtolower($part));
+            $i++;
+        }
+        if (!$capitalize) {
+            $outVarName = strtolower($outVarName);
+        }
+        $outVarName = trim($outVarName, $separator);
+        return $outVarName;
+    }
+}

--- a/app/partials/classes/handlers/DatabaseModelExtractor.php
+++ b/app/partials/classes/handlers/DatabaseModelExtractor.php
@@ -3,6 +3,7 @@
 namespace MMWS\Handler;
 
 use Dotenv\Exception\InvalidFileException;
+use MMWS\Handler\CaseHandler;
 use PDO;
 use PDOStatement;
 
@@ -105,12 +106,13 @@ class DatabaseModelExtractor
 
             foreach ($r as $each => $value) {
 
-                $className = $this->snake_to_camel($value['TABLE_NAME'], true);
+                $className = CaseHandler::convert($value['TABLE_NAME'], 0, true);
                 $this->snaked[$className] = $value['TABLE_NAME'];
 
                 $this->tables[$className][] = $this->snakeToCamel > 0
-                    ? $this->snake_to_camel(
+                    ? CaseHandler::convert(
                         $value['COLUMN_NAME'],
+                        0,
                         $this->snakeToCamel === 2 ? true : false
                     ) : $value['COLUMN_NAME'];
             }
@@ -278,51 +280,5 @@ class DatabaseModelExtractor
             }
         }
         return $r;
-    }
-
-    /**
-     * Changes the snake_case to camelCase from an array
-     * @param String $var variable name
-     */
-    private function snake_to_camel($content, Bool $capitalize = false)
-    {
-        if (is_array($content)) {
-            $output = array();
-            /** Loops through the array to get the keys */
-            foreach ($content as $key => $value) {
-                $parts = explode('_', $key);
-
-                $outVarName = '';
-                /** Loops through every name part separated by underscore (_) */
-                $i = 0;
-                foreach ($parts as $part) {
-                    if ($i === 0 && !$capitalize) {
-                        $outVarName = strtolower($part);
-                        $i++;
-                        continue;
-                    }
-                    $outVarName .= ucfirst(strtolower($part));
-                    $i++;
-                }
-                $output[$outVarName] = $value;
-            }
-            return $output;
-        }
-
-        $parts = explode('_', $content);
-
-        $outVarName = '';
-        /** Loops through every name part separated by underscore (_) */
-        $i = 0;
-        foreach ($parts as $part) {
-            if ($i === 0 && !$capitalize) {
-                $outVarName = strtolower($part);
-                $i++;
-                continue;
-            }
-            $outVarName .= ucfirst(strtolower($part));
-            $i++;
-        }
-        return $outVarName;
     }
 }


### PR DESCRIPTION
## Change log v0.9.3-alpha

 - [X] added a string case handler to deal with camel case to snake case converter and vice-versa

### Example

```
$values = [
    'userName' => 'Garry',
    'userPassword' => 'M&UhanL2'
];

$str = MMWS\Handler\CaseHandler::convert($values, 1);
```

`$str` will result in 
```
[
   'user_name' => 'Garry'
   'user_password' => 'M&UhanL2'
]
```

This will be usefull in a future auto CRUD modeler in MVC Creator.