### PR TITLE
fix: issue 12: auto generated entity data conflict for every field

### DIFF
--- a/app/routers/ws/v2.php
+++ b/app/routers/ws/v2.php
@@ -24,5 +24,4 @@
 use MMWS\Factory\EndpointFactory;
 
 return [
-
 ];

--- a/app/util/templates/classes/Entity.template
+++ b/app/util/templates/classes/Entity.template
@@ -39,7 +39,7 @@ class {CLASS_NAME}
                  * Checks if an instance with the same data already exists.
                  * Change this $fields to the wanted keys.
                  */
-                $instanceExists = $this->get(['filters' => $fields], false, false);
+                $instanceExists = $this->get(['filters' => $fields], false);
 
                 if(!sizeof($instanceExists)){
                     $stmt = new PDOQueryBuilder($this->model->table);
@@ -91,7 +91,7 @@ class {CLASS_NAME}
         if ($this->model->id) {
             return $this->getOne($filters, $asobj);
         } else {
-            return $this->getAll($filters, $asobj, $aggregator);
+            return $this->getAll($filters, $asobj, $aggregator === 'AND');
         }
     }
 
@@ -143,7 +143,7 @@ class {CLASS_NAME}
 
             $stmt->select($columns);
             if (isset($filters['filters'])) {
-                $stmt->setFilters($filters['filters'], false);
+                $stmt->setFilters($filters['filters'], $and);
             }
             // $stmt->order(['name' => 'ASC']);
             $instances = $stmt->run();


### PR DESCRIPTION
### Changelog
#12 

 - [X] Fixed database conflict for every field.

### Solution:
The template wasn't using correctly the aggregator AND.
```php
# before
// save()
$instanceExists = $this->get(['filters' => $fields], false, false);
// get()
return $this->getAll($filters, $asobj, $aggregator);

# after
// save()
$instanceExists = $this->get(['filters' => $fields], false);
// get()
return $this->getAll($filters, $asobj, $aggregator === 'AND');
```